### PR TITLE
Fix/Manifest declaration for the runtime stylesheet

### DIFF
--- a/views/js/pciCreator/ims/geogebrapci/imsPciCreator.json
+++ b/views/js/pciCreator/ims/geogebrapci/imsPciCreator.json
@@ -21,14 +21,12 @@
                 "interaction/runtime/js/GGBInteraction.min.js"
             ]
         },
-        "stylesheets" : [
-            "./interaction/runtime/css/wggb.css"
-        ],
         "src": [
             "./interaction/runtime/js/GGBInteraction.js",
             "./interaction/runtime/js/renderer.js",
             "./interaction/runtime/js/instancer.js",
-            "./interaction/runtime/js/lib/deployggb.js"
+            "./interaction/runtime/js/lib/deployggb.js",
+            "./interaction/runtime/css/wggb.css"
         ]
     },
     "creator": {


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/NSA-613

### Summary

Move the runtime stylesheet to the source files in the manifest.

### Details

In IMS format, the runtime part of the manifest must only contain `"hook", "modules", "src"`. Any source file must be placed under the `src` entry, no matter if they are JavaScript or not. However, the first file of the list must be a JavaScript file, and additional resources must be placed at the end of the list.

This fix makes sure the runtime stylesheet is also part of the source file, and then copied to the package. This also helps making work the development mode in TAO.

### How to test

- Check out the branch: `git checkout -t origin/oat-sa:extension-geogebra:fix/NSA-613/manifest-declaration`
- bundle the PCI: `cd tao/views/build && npx grunt portableelement -e=geogebra -i=GGBPCI`
- activate the [development mode](https://github.com/oat-sa/taohub-articles/blob/master/forge/pci-development.md), and check that the PCI reload when refreshing the item authoring.