### PR TITLE
Fix/runtime manifest

### DIFF
--- a/migrations/Version202409200641503559_geogebra.php
+++ b/migrations/Version202409200641503559_geogebra.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\geogebra\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+use oat\geogebra\scripts\install\RegisterPciGeogebraIMS;
+
+/**
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202409200641503559_geogebra extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addReport(
+            $this->propagate(
+                new RegisterPciGeogebraIMS()
+            )(
+                ['1.2.2']
+            )
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new IrreversibleMigration(
+            'In order to undo this migration, please revert the client-side changes and run ' . RegisterPciGeogebraIMS::class
+        );
+    }
+}

--- a/views/js/pciCreator/ims/geogebrapci/imsPciCreator.json
+++ b/views/js/pciCreator/ims/geogebrapci/imsPciCreator.json
@@ -21,14 +21,12 @@
                 "interaction/runtime/js/GGBInteraction.min.js"
             ]
         },
-        "stylesheets" : [
-            "./interaction/runtime/css/wggb.css"
-        ],
         "src": [
             "./interaction/runtime/js/GGBInteraction.js",
             "./interaction/runtime/js/renderer.js",
             "./interaction/runtime/js/instancer.js",
-            "./interaction/runtime/js/lib/deployggb.js"
+            "./interaction/runtime/js/lib/deployggb.js",
+            "./interaction/runtime/css/wggb.css"
         ]
     },
     "creator": {

--- a/views/js/pciCreator/ims/geogebrapci/imsPciCreator.json
+++ b/views/js/pciCreator/ims/geogebrapci/imsPciCreator.json
@@ -4,7 +4,7 @@
     "label": "GeoGebra for Teaching and Learning Math",
     "short": "GeoGebra",
     "description": "GeoGebra for Teaching and Learning Math",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "author": "Jean-Philippe Riviere",
     "email": "jean.philippe.riviere@gmail.com",
     "tags": [


### PR DESCRIPTION
### Summary

Here is a small set of corrections:

- the manifest file for the Geogebra PCI contained a wrong declaration for the runtime stylesheet, preventing us from using the developer's mode.
- the migration script for updating existing instances of TAO with the last version of the PCI

### Details

In IMS format, the runtime part of the manifest must only contain "hook", "modules", "src". Any source file must be placed under the src entry, no matter if they are JavaScript or not. However, the first file of the list must be a JavaScript file, and additional resources must be placed at the end of the list.

This fix makes sure the runtime stylesheet is also part of the source file, and then copied to the package. This also helps making work the development mode in TAO.

For updating existing instances of TAO, an extension needs to present migration scripts. Without this, the PCI will not be registered with the new version.

### How to test

Check out the branch: git checkout -t origin/oat-sa:extension-geogebra:fix/runtime-manifest
bundle the PCI: cd tao/views/build && npx grunt portableelement -e=geogebra -i=GGBPCI
activate the [development mode](https://github.com/oat-sa/taohub-articles/blob/master/forge/pci-development.md), and check that the PCI reload when refreshing the item authoring.